### PR TITLE
Fixing redirect uri to match new port number.

### DIFF
--- a/views/index.rhtml
+++ b/views/index.rhtml
@@ -20,7 +20,7 @@
 <form method="post" action="<%= chargify.base_uri %>/signups">
   <%= chargify.direct.secure_parameters(
     :data => {
-      :redirect_uri => "http://localhost:4567/verify"
+      :redirect_uri => "http://localhost:9292/verify"
     }
   ).to_form_inputs %>
   <fieldset>


### PR DESCRIPTION
The port number changed with bundler/rackup.  This updates the app so the verify step works again.
