### PR TITLE
Add card update example

### DIFF
--- a/chargify_direct_example_app.rb
+++ b/chargify_direct_example_app.rb
@@ -28,6 +28,35 @@ class ChargifyDirectExampleApp < Sinatra::Base
     end
   end
 
+  get '/card_update/:subscription_id' do
+    @subscription_id = params[:subscription_id]
+    erb :card_update
+  end
+
+  get '/verify_card_update' do
+    if chargify.direct.response_parameters(params).verified?
+      @call = chargify.calls.read(params[:call_id])
+
+      if @call.successful?
+        redirect "/card_update_receipt/#{@call.id}"
+      else
+        @subscription_id = chargify.calls.read(params[:call_id]).request.id
+        erb :card_update
+      end
+    else # Unverified redirect
+      erb :unverified_card_update
+    end
+  end
+
+  get '/card_update_receipt/:call_id' do
+    @call = chargify.calls.read(params[:call_id])
+    if @call
+      erb :card_update_receipt
+    else
+      not_found
+    end
+  end
+
   not_found do
     "Not found"
   end

--- a/views/card_update.rhtml
+++ b/views/card_update.rhtml
@@ -1,0 +1,69 @@
+<h1>Update Cards for Acme Projects</h1>
+
+<% if @call && !@call.errors.empty? %>
+<div class="errors">
+  <p><strong>Could not complete update. Please correct the following problems:</strong></p>
+  <ul>
+    <% @call.errors.each do |error| %>
+    <li><%= error.message %></li>
+    <% end %>
+  </ul>
+</div>
+<% end %>
+
+<% if @flash %>
+<div class="errors">
+  <p><strong><%= @flash %></strong></p>
+</div>
+<% end %>
+
+<form method="post" action="<%= chargify.base_uri %>/subscriptions/<%= @subscription_id %>/card_update">
+  <%= chargify.direct.secure_parameters(
+    :data => {
+      :redirect_uri => "http://localhost:9292/verify_card_update",
+      :subscription_id => @subscription_id
+    },
+    :timestamp => (Time.now.to_i),
+    :nonce => SecureRandom.urlsafe_base64(40)
+  ).to_form_inputs %>
+  <fieldset>
+    <legend>Payment Profile</legend>
+
+    <p>
+      <label for="payment_profile_first_name">First Name on Card</label><br/>
+      <input type="text" name="payment_profile[first_name]" id="payment_profile_first_name" value="<%= h(payment_profile_params[:first_name]) %>" />
+    </p>
+    
+    <p>
+      <label for="payment_profile_first_name">Last Name on Card</label><br/>
+      <input type="text" name="payment_profile[last_name]" id="payment_profile_last_name" value="<%= h(payment_profile_params[:last_name]) %>" />
+    </p>
+    
+    <p>
+      <label for="payment_profile_card_number">Card Number</label><br/>
+      <input type="text" name="payment_profile[card_number]" id="payment_profile_card_number" value="<%= h(payment_profile_params[:card_number]) %>" />
+    </p>
+    
+    <p>
+      Expiration <label for="payment_profile_expiration_month">Month</label> / <label for="payment_profile_expiration_year">Year</label><br/>
+      <select name="payment_profile[expiration_month]" id="payment_profile_expiration_month">
+        <% for i in 1..12 do %>
+        <option value="<%= i %>"<%= ' selected' if payment_profile_params[:expiration_month] == i.to_s %>><%= "%02d" % i.to_s %></option>
+        <% end %>
+      </select>
+      /
+      <select name="payment_profile[expiration_year]" id="payment_profile_expiration_year">
+        <% t = Time.now.year; for i in t..(t+10) %>
+        <option value="<%= i %>"<%= ' selected' if payment_profile_params[:expiration_year] == i.to_s %>><%= i %></option>
+        <% end %>
+      </select>
+    </p>
+  </fieldset>
+  
+  <p>
+    <input type="submit" value="Update Card" />
+    or
+    <a href="/">Go Back</a>
+  </p>
+    
+</form>

--- a/views/card_update_receipt.rhtml
+++ b/views/card_update_receipt.rhtml
@@ -1,0 +1,11 @@
+<h1>Card Update Success</h1>
+
+<p>
+  You have successfully updated the card information.
+</p>
+<p>
+  You may fetch this call from <%= chargify.base_uri %>/calls/<%= @call.id %> using your API V2 credentials.  See
+  <a href="https://developer.chargify.com/content/chargify-direct/overview.html#fetching-the-call">
+    https://developer.chargify.com/content/chargify-direct/overview.html#fetching-the-call
+  </a> for details.
+</p>

--- a/views/unverified_card_update.rhtml
+++ b/views/unverified_card_update.rhtml
@@ -1,0 +1,10 @@
+<h1>Verification Error</h1>
+
+<p>
+  The previous card update attempt encountered an error during verification.  This means that we cannot be 100%
+  sure if the signup was successful or not.
+</p>
+
+<p>
+  You can try contacting us or updating the card again.
+</p>


### PR DESCRIPTION
This PR adds an example of how to make use of Chargify Direct to update a card on a subscription.  Given the ID of a subscription, navigating to `http://localhost:9292/card_update/<SUBSCRIPTION_ID>` where `<SUBSCRIPTION_ID>` is the numeric subscription ID, the user is presented with a form to input the updated card information.  It does NOT display the existing card information.  If an error occurs after submitting, the form will be redisplayed along with error messaging.  Otherwise, a success message is displayed along with the URI for retrieving the call data from the API V2.
  